### PR TITLE
add missing comma to __linux__ def

### DIFF
--- a/src/Gem/Settings.cpp
+++ b/src/Gem/Settings.cpp
@@ -36,7 +36,7 @@
 #define GEM_SETTINGS_FILE "gem.conf"
 static const char*s_configdir[] = {
 #ifdef __linux__
-  "~/Documents/plugdata/Extra/Gem"
+  "~/Documents/plugdata/Extra/Gem",
 #elif defined __APPLE__
   "~/Documents/plugdata/Extra/Gem",
 #elif defined  _WIN32


### PR DESCRIPTION
I had broken build without this comma. results in a faulty array:

```gcc
/home/dreamer/Sources/_audio/plugdata/Libraries/Gem/src/Gem/Settings.cpp:45:3: error: expected ‘}’ before numeric constant
   45 |   0 /* $(pwd)/gem.conf */
      |   ^
/home/dreamer/Sources/_audio/plugdata/Libraries/Gem/src/Gem/Settings.cpp:37:35: note: to match this ‘{’
   37 | static const char*s_configdir[] = {
      |                                   ^
/home/dreamer/Sources/_audio/plugdata/Libraries/Gem/src/Gem/Settings.cpp:45:3: error: expected ‘,’ or ‘;’ before numeric constant
   45 |   0 /* $(pwd)/gem.conf */
      |   ^
/home/dreamer/Sources/_audio/plugdata/Libraries/Gem/src/Gem/Settings.cpp:46:1: error: expected declaration before ‘}’ token
   46 | };
      | ^
```